### PR TITLE
Update README with Windows compile note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ cd backend
 python app.py
 ```
 
-The app will auto-install requirements on first run.
+The app will auto-install requirements on first run and compile Python files.
+On Windows you may see a warning like `Can't list ... python*.zip` during this
+compile step. As long as no other errors appear, you can safely ignore it.
 
 3. In another terminal install frontend deps and start React dev server:
 


### PR DESCRIPTION
## Summary
- clarify that the backend compiles Python files on startup
- note that Windows users may see a harmless `Can't list ... python*.zip` warning

## Testing
- `npm install`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6865a78cfa5083269fa5a99ffdf5e243